### PR TITLE
Fix 'timerDidFire()' not exposed to objective-c

### DIFF
--- a/Sources/Ripple.swift
+++ b/Sources/Ripple.swift
@@ -145,7 +145,7 @@ open class Ripple: NSObject {
     ripple.layer.add(animationGroup, forKey: "ripple")
   }
   
-  func timerDidFire() {
+  @objc func timerDidFire() {
     activate()
   }
 }


### PR DESCRIPTION
Expose 'timerDidFire()' selector to objective-c to fix errors when building.